### PR TITLE
Add support for virtual zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ Designed to work with Home Assistant.  Uses MQTT discovery to create sensors
 for all zones and the alarm panel automatically.  Times are passed in the
 MQTT messages and retained so they can be used to create real "last changed"
 time sensors if desired in HASS.
+
+If you use virtual zones, you need to enable the corresponding zone expander
+emulation in the Alarm Decoder setup. Then, you can include `is_virtual=True`
+in a Zone configuration, and it will get a switch that can be used to trigger
+the emulated zone fault.

--- a/ad_mqtt/Devices.py
+++ b/ad_mqtt/Devices.py
@@ -15,13 +15,14 @@ def init_devices(devices):
 
 
 class Zone:
-    def __init__(self, zone, entity, label, device_class=None):
+    def __init__(self, zone, entity, label, device_class=None, is_virtual=False):
         self.zone = zone   # int zone number
         self.entity = entity
         self.label = label
         self.faulted = None  # None=Unknown, True=faulted, False=clear
         self.has_battery = False
         self.unique_id = None
+        self.is_virtual = is_virtual
         self.device_class = device_class if device_class else \
                             guess_class((entity, label))
 
@@ -47,6 +48,7 @@ class_keywords = {
     "fire" : "smoke",
     "door" : "door",
     "window" : "window",
+    "heat": "heat",
     }
 
 

--- a/ad_mqtt/Discovery.py
+++ b/ad_mqtt/Discovery.py
@@ -181,6 +181,29 @@ class Discovery:
                     }
                 self.messages.append((topic, payload))
 
+            if z.is_virtual:
+                fault_entity = z.entity + '_fault'
+                fault_unique_id = z.unique_id + "_fault"
+                topic = f'homeassistant/switch/{fault_unique_id}/config'
+                state_topic = bridge.virtual_zone_state_topic.format(
+                    unique_id=fault_entity, entity=fault_unique_id)
+                set_topic = bridge.virtual_zone_set_topic.format(
+                    unique_id=fault_entity, entity=fault_unique_id)
+                payload = {
+                    'name' : z.label + ' Fault',
+                    'object_id' : fault_entity,
+                    'unique_id' : fault_unique_id,
+                    'device' : Discovery.device,
+                    'state_topic' : state_topic,
+                    'value_template' : '{{value_json.status}}',
+                    'json_attributes_topic' : state_topic,
+                    'json_attributes_template' : attr_templ,
+                    'command_topic' : set_topic,
+                    'qos' : 1,
+                    'retain' : True,
+                    }
+                self.messages.append((topic, payload))
+
     def mqtt_connected(self, device, connected):
         if not self.messages:
             return

--- a/run.py
+++ b/run.py
@@ -39,6 +39,7 @@ devices = [
     # Zone( zone_number, HAS_entity_name, description, device_class )
     AD.Zone(1, "fire", "Fire Alarm", "smoke"),
     AD.Zone(2, "basement_door", "Basement Door"),
+    AD.Zone(9, "virtual_zone", "Make sure you enabled the corresponding expander emulation in the alarm decoder", is_virtual=True),
     # RF zone ( serial_number, zone_number, HAS_entity_name, description )
     AD.RfZone( 12345, 25, "front_door", "Front Door"),
     AD.RfZone( 12345, 27, "dining_room_door", "Dining Room Door"),


### PR DESCRIPTION
This exposes the virtual zone functionality of the alarmdecoder, with HomeAssistant autodiscovery.

It makes a switch that faults the zone. I confirmed this works on my AlarmDecoder.

Handles https://github.com/TD22057/ad-mqtt/issues/16 , and this codebase was very straightforward, so thanks!